### PR TITLE
Remove React pure function transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ module.exports = {
     require("babel-preset-react")
   ],
   plugins: [
-    require("babel-plugin-react-pure-components")["default"],
     require("babel-plugin-transform-export-extensions"),
     require("babel-plugin-transform-class-properties"),
     [require("babel-plugin-transform-es2015-template-literals"), { loose: true }],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "BSD-3",
   "main": "index.js",
   "dependencies": {
-    "babel-plugin-react-pure-components": "^2.2.2",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-es2015-arrow-functions": "^6.4.0",
     "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",


### PR DESCRIPTION
I kept fighting to make this transform work, but I think I finally met my match: https://github.com/thejameskyle/babel-react-optimize/issues/18

This PR removes the Babel transform that takes stateless React classes and turns them into plain functions.

We will need to republish builds of our components after this change in cf-ui.

@jwineman @akenn @wyuenho @marksteyn
